### PR TITLE
Compat and Mod Patches

### DIFF
--- a/1.6/NanoGlassPatch/Patches/NanoGlassPatch.xml
+++ b/1.6/NanoGlassPatch/Patches/NanoGlassPatch.xml
@@ -1,0 +1,291 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+	<Operation Class="PatchOperationAdd">
+		<success>Always</success>
+        <xpath>/Defs/ThingDef[defName="PassengerShuttle"]/costList</xpath>
+        <value>
+			<ReinforcedGlass>10</ReinforcedGlass>
+        </value>
+    </Operation>
+	
+	<Operation Class="PatchOperationAdd">
+        <xpath>/Defs/ThingDef[defName="SolarGenerator"]/costList</xpath>
+        <value>
+			<Glass>32</Glass>
+        </value>
+    </Operation>
+	
+	<Operation Class="PatchOperationAdd">
+		<success>Always</success>
+        <xpath>/Defs/ThingDef[defName="ShipLandingBeacon"]/costList</xpath>
+        <value>
+			<LargeCircularGlass>1</LargeCircularGlass>
+        </value>
+    </Operation>
+
+	<Operation Class="PatchOperationReplace">
+        <xpath>/Defs/ThingDef[defName="OutdoorGroundLamp"]/costList</xpath>
+        <value>
+            <costList>
+			  <Steel>7</Steel>
+			  <LargeCircularGlass>1</LargeCircularGlass>
+			</costList>
+        </value>
+    </Operation>
+	
+	<Operation Class="PatchOperationReplace">
+        <xpath>/Defs/ThingDef[defName="GLRoundWallLamp"]/costList</xpath>
+        <value>
+            <costList>
+			  <Steel>10</Steel>
+			  <LargeCircularGlass>1</LargeCircularGlass>
+			</costList>
+        </value>
+    </Operation>
+	
+	<Operation Class="PatchOperationAdd">
+		<success>Always</success>
+		<xpath>/Defs/ThingDef[defName="FueledGlassworkTable"]/recipes</xpath>
+		<value>
+			<li>MakeCircularGlass</li>
+		</value>
+	</Operation>
+<!-- Add LargeCircularGlass to lamps with "standing lamp" in label -->
+	<Operation Class="PatchOperationAdd">
+		<success>Always</success>
+		<xpath>/Defs/ThingDef[contains(label, 'standing lamp')]/costList</xpath>
+		<value>
+			<LargeCircularGlass>1</LargeCircularGlass>
+		</value>
+	</Operation>
+	
+	<!-- Add LargeCircularGlass to lamps with "desk lamp" in label -->
+	<Operation Class="PatchOperationAdd">
+		<success>Always</success>
+		<xpath>/Defs/ThingDef[contains(label, 'desk lamp')]/costList</xpath>
+		<value>
+			<LargeCircularGlass>1</LargeCircularGlass>
+		</value>
+	</Operation>
+	
+	<!-- Add LargeCircularGlass to lamps with "sun lamp" in label -->
+	<Operation Class="PatchOperationAdd">
+		<success>Always</success>
+		<xpath>/Defs/ThingDef[contains(label, 'sun lamp')]/costList</xpath>
+		<value>
+			<LargeCircularGlass>1</LargeCircularGlass>
+		</value>
+	</Operation>
+	
+	<!-- Add Glass to lamps with "floor lamp" in label -->
+	<Operation Class="PatchOperationAdd">
+		<success>Always</success>
+		<xpath>/Defs/ThingDef[contains(label, 'floor lamp')]/costList</xpath>
+		<value>
+			<Glass>1</Glass>
+		</value>
+	</Operation>
+	
+	<!-- Add Glass to lamps with "outdoor lamp" in label -->
+	<Operation Class="PatchOperationAdd">
+		<success>Always</success>
+		<xpath>/Defs/ThingDef[contains(label, 'outdoor lamp')]/costList</xpath>
+		<value>
+			<Glass>1</Glass>
+		</value>
+	</Operation>
+	
+	<!-- Add Glass to lamps with "outdoor solar lamp" in label -->
+	<Operation Class="PatchOperationAdd">
+		<success>Always</success>
+		<xpath>/Defs/ThingDef[contains(label, 'outdoor solar lamp')]/costList</xpath>
+		<value>
+			<Glass>1</Glass>
+		</value>
+	</Operation>
+	
+	<!-- Add Glass to lamps with "flood light" in label -->
+	<Operation Class="PatchOperationAdd">
+		<success>Always</success>
+		<xpath>/Defs/ThingDef[contains(label, 'flood light')]/costList</xpath>
+		<value>
+			<Glass>1</Glass>
+		</value>
+	</Operation>
+	
+	<!-- Replace wall lamp costList to always be 10 Steel + 1 Glass -->
+	<Operation Class="PatchOperationReplace">
+		<success>Always</success>
+		<xpath>/Defs/ThingDef[defName="WallLamp"]/costList</xpath>
+		<value>
+			<costList>
+				<Steel>10</Steel>
+				<Glass>1</Glass>
+			</costList>
+		</value>
+	</Operation>
+	
+	<!-- Ceiling lights (not long) -->
+	  <Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[contains(label, 'ceiling light') and not(contains(label, 'long ceiling light'))]</xpath>
+		<value>
+		  <costList>
+			<LargeCircularGlass>1</LargeCircularGlass>
+		  </costList>
+		</value>
+		<success>Always</success>
+	  </Operation>
+		
+	<!-- Add LargeCircularGlass to long ceiling light -->
+	  <Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Owl_LongCeilingLight"]/costList</xpath>
+		<value>
+		  <Glass>2</Glass>
+		</value>
+		<success>Always</success>
+	  </Operation>
+	
+	<!-- Add 1 Glass to lamps with "light column" in label -->
+	<Operation Class="PatchOperationAdd">
+		<success>Always</success>
+		<xpath>/Defs/ThingDef[contains(label, 'light column')]/costList</xpath>
+		<value>
+			<Glass>1</Glass>
+		</value>
+	</Operation>
+	
+	<!-- Add 2 Glass to lamps with "crystal column" in label -->
+	<Operation Class="PatchOperationAdd">
+		<success>Always</success>
+		<xpath>/Defs/ThingDef[contains(label, 'crystal column')]/costList</xpath>
+		<value>
+			<Glass>2</Glass>
+		</value>
+	</Operation>
+	
+	<!-- Add 3 Glass to lamps with "sun column" in label -->
+	<Operation Class="PatchOperationAdd">
+		<success>Always</success>
+		<xpath>/Defs/ThingDef[contains(label, 'sun column')]/costList</xpath>
+		<value>
+			<Glass>3</Glass>
+		</value>
+	</Operation>
+	
+	<!-- Add 2 Glass to lamps with "sun pad" in label -->
+	<Operation Class="PatchOperationAdd">
+		<success>Always</success>
+		<xpath>/Defs/ThingDef[contains(label, 'sun pad')]/costList</xpath>
+		<value>
+			<Glass>2</Glass>
+		</value>
+	</Operation>
+	
+	<!-- Add 1 Glass to "arcade machine" -->
+	<Operation Class="PatchOperationAdd">
+		<success>Always</success>
+		<xpath>/Defs/ThingDef[contains(label, 'arcade machine')]/costList</xpath>
+		<value>
+			<Glass>1</Glass>
+		</value>
+	</Operation>
+	
+	<!-- Add 1 Glass to "old computer" -->
+	<Operation Class="PatchOperationAdd">
+		<success>Always</success>
+		<xpath>/Defs/ThingDef[contains(label, 'old computer')]/costList</xpath>
+		<value>
+			<Glass>1</Glass>
+		</value>
+	</Operation>
+	
+	<!-- Add 2 Glass to "modern computer" -->
+	<Operation Class="PatchOperationAdd">
+		<success>Always</success>
+		<xpath>/Defs/ThingDef[contains(label, 'modern computer')]/costList</xpath>
+		<value>
+			<Glass>2</Glass>
+		</value>
+	</Operation>
+	
+	<!-- Add 1 Glass to "tube television" -->
+	<Operation Class="PatchOperationAdd">
+		<success>Always</success>
+		<xpath>/Defs/ThingDef[contains(label, 'tube television')]/costList</xpath>
+		<value>
+			<Glass>1</Glass>
+		</value>
+	</Operation>
+	
+	<!-- Add 2 Glass to "flatscreen television" -->
+	<Operation Class="PatchOperationAdd">
+		<success>Always</success>
+		<xpath>/Defs/ThingDef[contains(label, 'flatscreen television')]/costList</xpath>
+		<value>
+			<Glass>2</Glass>
+		</value>
+	</Operation>
+	
+	<!-- Add 2 Glass to "wall-mounted television" -->
+	<Operation Class="PatchOperationAdd">
+		<success>Always</success>
+		<xpath>/Defs/ThingDef[contains(label, 'wall-mounted television')]/costList</xpath>
+		<value>
+			<Glass>2</Glass>
+		</value>
+	</Operation>
+	
+	<!-- Add 3 Glass to "megascreen television" -->
+	<Operation Class="PatchOperationAdd">
+		<success>Always</success>
+		<xpath>/Defs/ThingDef[contains(label, 'megascreen television')]/costList</xpath>
+		<value>
+			<Glass>3</Glass>
+		</value>
+	</Operation>
+	
+	<!-- Add 6 Glass to "hyperscreen television" -->
+	<Operation Class="PatchOperationAdd">
+		<success>Always</success>
+		<xpath>/Defs/ThingDef[contains(label, 'hyperscreen television')]/costList</xpath>
+		<value>
+			<Glass>6</Glass>
+		</value>
+	</Operation>
+	
+	<!-- Add 2 Glass to regular mirrors -->
+	<Operation Class="PatchOperationAdd">
+	<success>Always</success>
+	  <xpath>Defs/ThingDef[contains(label, 'mirror') and not(contains(label, 'royal'))]/costList</xpath>
+	  <value>
+		<Glass>2</Glass>
+	  </value>
+	</Operation>
+
+	<!-- Add 4 Glass and Silver to royal mirrors -->
+	<Operation Class="PatchOperationConditional">
+	<success>Always</success>
+	  <xpath>Defs/ThingDef[contains(label, 'royal mirror')]</xpath>
+	  <match Class="PatchOperationSequence">
+		<operations>
+		  <!-- Create costList if it doesn't exist -->
+		  <li Class="PatchOperationAdd">
+			<success>Always</success>
+			<xpath>Defs/ThingDef[contains(label, 'royal mirror')][not(costList)]</xpath>
+			<value>
+			  <costList/>
+			</value>
+		  </li>
+		  <!-- Add glass and silver costs -->
+		  <li Class="PatchOperationAdd">
+			<success>Always</success>
+			<xpath>Defs/ThingDef[contains(label, 'royal mirror')]/costList</xpath>
+			<value>
+			  <Glass>4</Glass>
+			  <Silver>100</Silver>
+			</value>
+		  </li>
+		</operations>
+	  </match>
+	</Operation>
+</Patch>

--- a/1.6/OwlWallUtils/Patches/OwlWallUtilsPatch.xml
+++ b/1.6/OwlWallUtils/Patches/OwlWallUtilsPatch.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+  <!-- Remove the base and all concrete lamps derived from it -->
+  <Operation Class="PatchOperationRemove">
+    <xpath>/Defs/ThingDef[defName="GLCeilingLamp"]</xpath>
+  </Operation>
+  <Operation Class="PatchOperationRemove">
+    <xpath>/Defs/ThingDef[defName="GLCeilingLamp_Red"]</xpath>
+  </Operation>
+  <Operation Class="PatchOperationRemove">
+    <xpath>/Defs/ThingDef[defName="GLCeilingLamp_Blue"]</xpath>
+  </Operation>
+  <Operation Class="PatchOperationRemove">
+    <xpath>/Defs/ThingDef[defName="GLCeilingLamp_Green"]</xpath>
+  </Operation>
+  <Operation Class="PatchOperationRemove">
+    <xpath>/Defs/ThingDef[defName="GLCeilingLamp_Violet"]</xpath>
+  </Operation>
+  <Operation Class="PatchOperationRemove">
+    <xpath>/Defs/ThingDef[defName="GLCeilingLamp_Yellow"]</xpath>
+  </Operation>
+  <Operation Class="PatchOperationRemove">
+    <xpath>/Defs/ThingDef[defName="GLCeilingLamp_Orange"]</xpath>
+  </Operation>
+
+</Patch>

--- a/1.6/Patches/Pots_Soil_Patches.xml
+++ b/1.6/Patches/Pots_Soil_Patches.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+  <!-- Target PlantPot -->
+  <Operation Class="PatchOperationConditional">
+    <xpath>Defs/ThingDef[defName='PlantPot']</xpath>
+    <match Class="PatchOperationSequence">
+      <operations>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ThingDef[defName='PlantPot'][not(costList)]</xpath>
+          <value>
+            <costList/>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ThingDef[defName='PlantPot']/costList</xpath>
+          <value>
+            <SR_Soil>2</SR_Soil>
+          </value>
+        </li>
+      </operations>
+    </match>
+  </Operation>
+  
+  <!-- Target PlantPot_Bonsai -->
+  <Operation Class="PatchOperationConditional">
+    <xpath>Defs/ThingDef[defName='PlantPot_Bonsai']</xpath>
+    <match Class="PatchOperationSequence">
+      <operations>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ThingDef[defName='PlantPot_Bonsai'][not(costList)]</xpath>
+          <value>
+            <costList/>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ThingDef[defName='PlantPot_Bonsai']/costList</xpath>
+          <value>
+            <SR_Soil>2</SR_Soil>
+          </value>
+        </li>
+      </operations>
+    </match>
+  </Operation>
+  
+  <!-- Target VFE_LongPlantPot -->
+  <Operation Class="PatchOperationConditional">
+    <xpath>Defs/ThingDef[defName='VFE_LongPlantPot']</xpath>
+    <match Class="PatchOperationSequence">
+      <operations>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ThingDef[defName='VFE_LongPlantPot'][not(costList)]</xpath>
+          <value>
+            <costList/>
+          </value>
+        </li>
+        <li Class="PatchOperationAdd">
+          <xpath>Defs/ThingDef[defName='VFE_LongPlantPot']/costList</xpath>
+          <value>
+            <SR_Soil>2</SR_Soil>
+          </value>
+        </li>
+      </operations>
+    </match>
+  </Operation>
+</Patch>

--- a/1.6/RebuildPatchNanoGlass/Patches/Rebuild_patch2_nano.xml
+++ b/1.6/RebuildPatchNanoGlass/Patches/Rebuild_patch2_nano.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+	<!-- Replace product nodes -->
+	<Operation Class="PatchOperationReplace">
+	  <xpath>//products/RB_Glass</xpath>
+	  <value>
+		<Glass>1</Glass>
+	  </value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+	  <xpath>//products/RB_BallisticGlass</xpath>
+	  <value>
+		<ReinforcedGlass>1</ReinforcedGlass>
+	  </value>
+	</Operation>
+
+	<!-- Replace costList nodes -->
+	<Operation Class="PatchOperationReplace">
+	  <xpath>//costList/RB_Glass</xpath>
+	  <value>
+		<Glass>20</Glass>
+	  </value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+	  <xpath>//costList/RB_BallisticGlass</xpath>
+	  <value>
+		<ReinforcedGlass>20</ReinforcedGlass>
+	  </value>
+	</Operation>
+  
+	<!-- Remove RB_Make_GlassFromChunks from ElectricSmelter -->
+	<Operation Class="PatchOperationRemove">
+	  <xpath>/Defs/ThingDef[defName="ElectricSmelter"]/recipes/li[text()="RB_Make_GlassFromChunks"]</xpath>
+	</Operation>
+
+	<!-- Remove RB_Make_BallisticGlassFromChunks from FabricationBench -->
+	<Operation Class="PatchOperationRemove">
+	  <xpath>/Defs/ThingDef[defName="FabricationBench"]/recipes/li[text()="RB_Make_BallisticGlassFromChunks"]</xpath>
+	</Operation>
+  
+  <!-- Remove ThingDefs -->
+  <Operation Class="PatchOperationRemove">
+    <xpath>/Defs/ThingDef[defName="AutoDoorGlass"]</xpath>
+  </Operation>
+  <Operation Class="PatchOperationRemove">
+    <xpath>/Defs/ThingDef[defName='Window']</xpath>
+  </Operation>
+<!--   <Operation Class="PatchOperationRemove">
+    <xpath>/Defs/ThingDef[defName='RB_Glass']</xpath>
+  </Operation>
+  <Operation Class="PatchOperationRemove">
+    <xpath>/Defs/ThingDef[defName='RB_BallisticGlass']</xpath>
+  </Operation> -->
+</Patch>

--- a/1.6/RimatomicsConcrete/Patches/RimatomicsConcrete_patch.xml
+++ b/1.6/RimatomicsConcrete/Patches/RimatomicsConcrete_patch.xml
@@ -1,0 +1,162 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+    <!-- Reactor Core A - Add concrete for biological shielding -->
+    <Operation Class="PatchOperationReplace">
+        <xpath>/Defs/ThingDef[defName="ReactorCoreA"]/costList</xpath>
+        <value>
+            <costList>
+                <VFEC_BlocksConcrete>200</VFEC_BlocksConcrete>
+                <Steel>250</Steel>
+                <ComponentIndustrial>12</ComponentIndustrial>
+            </costList>
+        </value>
+    </Operation>
+
+    <!-- Reactor Core B - More concrete for larger reactor -->
+    <Operation Class="PatchOperationReplace">
+        <xpath>/Defs/ThingDef[defName="ReactorCoreB"]/costList</xpath>
+        <value>
+            <costList>
+                <VFEC_BlocksConcrete>300</VFEC_BlocksConcrete>
+                <Steel>250</Steel>
+                <Plasteel>50</Plasteel>
+                <ComponentIndustrial>16</ComponentIndustrial>
+                <ComponentSpacer>3</ComponentSpacer>
+            </costList>
+        </value>
+    </Operation>
+
+    <!-- Reactor Core C - Most concrete for massive reactor -->
+    <Operation Class="PatchOperationReplace">
+        <xpath>/Defs/ThingDef[defName="ReactorCoreC"]/costList</xpath>
+        <value>
+            <costList>
+                <VFEC_BlocksConcrete>400</VFEC_BlocksConcrete>
+                <Steel>300</Steel>
+                <Plasteel>150</Plasteel>
+                <ComponentIndustrial>24</ComponentIndustrial>
+                <ComponentSpacer>6</ComponentSpacer>
+            </costList>
+        </value>
+    </Operation>
+
+    <!-- Storage Pool - Concrete shielding structure -->
+    <Operation Class="PatchOperationReplace">
+        <xpath>/Defs/ThingDef[defName="storagePool"]/costList</xpath>
+        <value>
+            <costList>
+                <VFEC_BlocksConcrete>300</VFEC_BlocksConcrete>
+                <Steel>150</Steel>
+                <ComponentIndustrial>6</ComponentIndustrial>
+            </costList>
+        </value>
+    </Operation>
+
+    <!-- Cooling Tower - Concrete structure -->
+    <Operation Class="PatchOperationReplace">
+        <xpath>/Defs/ThingDef[defName="CoolingTower"]/costList</xpath>
+        <value>
+            <costList>
+                <VFEC_BlocksConcrete>800</VFEC_BlocksConcrete>
+                <Steel>200</Steel>
+                <ComponentIndustrial>12</ComponentIndustrial>
+            </costList>
+        </value>
+    </Operation>
+
+    <!-- Large Turbines - Add concrete foundations -->
+    <Operation Class="PatchOperationReplace">
+        <xpath>/Defs/ThingDef[defName="Turbine"]/costList</xpath>
+        <value>
+            <costList>
+                <VFEC_BlocksConcrete>50</VFEC_BlocksConcrete>
+                <Steel>200</Steel>
+                <turbineBlade>250</turbineBlade>
+                <ComponentIndustrial>12</ComponentIndustrial>
+            </costList>
+        </value>
+    </Operation>
+
+    <Operation Class="PatchOperationReplace">
+        <xpath>/Defs/ThingDef[defName="BigTurbine"]/costList</xpath>
+        <value>
+            <costList>
+                <VFEC_BlocksConcrete>150</VFEC_BlocksConcrete>
+                <Steel>500</Steel>
+                <turbineBlade>1000</turbineBlade>
+                <ComponentIndustrial>20</ComponentIndustrial>
+                <ComponentSpacer>2</ComponentSpacer>
+            </costList>
+        </value>
+    </Operation>
+
+    <!-- Add concrete to Research Reactor -->
+  <Operation Class="PatchOperationAdd">
+    <xpath>/Defs/ThingDef[defName="ResearchReactor"]/costList</xpath>
+    <value>
+      <VFEC_BlocksConcrete>30</VFEC_BlocksConcrete>
+    </value>
+  </Operation>
+
+  <!-- Add concrete to Plutonium Processor -->
+  <Operation Class="PatchOperationAdd">
+    <xpath>/Defs/ThingDef[defName="PlutoniumProcessor"]/costList</xpath>
+    <value>
+      <VFEC_BlocksConcrete>60</VFEC_BlocksConcrete>
+    </value>
+  </Operation>
+
+  <!-- Add concrete to Water Cooling System -->
+  <Operation Class="PatchOperationAdd">
+    <xpath>/Defs/ThingDef[defName="CoolingWater"]/costList</xpath>
+    <value>
+      <VFEC_BlocksConcrete>50</VFEC_BlocksConcrete>
+    </value>
+  </Operation>
+
+  <!-- Replace costList for BaseSarc (abstract parent) -->
+  <Operation Class="PatchOperationSequence">
+  <operations>
+    <li Class="PatchOperationAdd">
+      <xpath>/Defs/ThingDef[@ParentName="BaseSarc" and not(costList)]</xpath>
+      <value>
+        <costList>
+          <VFEC_BlocksConcrete>250</VFEC_BlocksConcrete>
+          <Steel>100</Steel>
+        </costList>
+      </value>
+    </li>
+    <li Class="PatchOperationAdd">
+      <xpath>/Defs/ThingDef[@ParentName="BaseSarc" and costList]/costList</xpath>
+      <value>
+        <VFEC_BlocksConcrete>250</VFEC_BlocksConcrete>
+      </value>
+    </li>
+  </operations>
+</Operation>
+
+    <!-- Radiation Shielding Wall - Concrete with DU and steel reinforcement -->
+    <Operation Class="PatchOperationReplace">
+        <xpath>/Defs/ThingDef[defName="RadiationShielding"]/costList</xpath>
+        <value>
+            <costList>
+                <VFEC_BlocksConcrete>3</VFEC_BlocksConcrete>
+                <DepletedUraniumPellets>10</DepletedUraniumPellets>
+                <Steel>2</Steel>
+            </costList>
+        </value>
+    </Operation>
+
+    <!-- DU Blast Door - Concrete core with steel cladding -->
+    <Operation Class="PatchOperationReplace">
+        <xpath>/Defs/ThingDef[defName="DU_Blastdoor"]/costList</xpath>
+        <value>
+            <costList>
+                <VFEC_BlocksConcrete>20</VFEC_BlocksConcrete>
+                <DepletedUraniumPellets>25</DepletedUraniumPellets>
+                <Steel>20</Steel>
+                <ComponentIndustrial>2</ComponentIndustrial>
+            </costList>
+        </value>
+    </Operation>
+</Patch>

--- a/1.6/RimefellerConcrete/Patches/RimefellerConcrete_patch.xml
+++ b/1.6/RimefellerConcrete/Patches/RimefellerConcrete_patch.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+  <!-- Deep Oil Well - Advanced drilling requires concrete foundation -->
+  <Operation Class="PatchOperationReplace">
+    <xpath>/Defs/ThingDef[defName="DeepOilWell"]/costList</xpath>
+    <value>
+      <costList>
+        <Steel>120</Steel>
+        <ComponentIndustrial>6</ComponentIndustrial>
+        <VFEC_BlocksConcrete>25</VFEC_BlocksConcrete>
+      </costList>
+    </value>
+  </Operation>
+
+  <!-- Large Chemfuel Powerplant - Major power generation facility -->
+  <Operation Class="PatchOperationReplace">
+    <xpath>/Defs/ThingDef[defName="LargeFuelPowerplant"]/costList</xpath>
+    <value>
+      <costList>
+        <Steel>800</Steel>
+        <ComponentIndustrial>16</ComponentIndustrial>
+        <VFEC_BlocksConcrete>50</VFEC_BlocksConcrete>
+      </costList>
+    </value>
+  </Operation>
+
+  <!-- Crude Cracker - Massive 6x6 chemical processing facility -->
+  <Operation Class="PatchOperationReplace">
+    <xpath>/Defs/ThingDef[defName="CrudeCracker"]/costList</xpath>
+    <value>
+      <costList>
+        <Steel>340</Steel>
+        <ComponentIndustrial>8</ComponentIndustrial>
+        <VFEC_BlocksConcrete>75</VFEC_BlocksConcrete>
+      </costList>
+    </value>
+  </Operation>
+
+  <!-- Oil Storage - Large crude oil containment tank -->
+  <Operation Class="PatchOperationReplace">
+    <xpath>/Defs/ThingDef[defName="OilStorage"]/costList</xpath>
+    <value>
+      <costList>
+        <Steel>100</Steel>
+        <ComponentIndustrial>1</ComponentIndustrial>
+        <VFEC_BlocksConcrete>30</VFEC_BlocksConcrete>
+      </costList>
+    </value>
+  </Operation>
+
+  <!-- Chemfuel Storage - Large chemfuel containment tank -->
+  <Operation Class="PatchOperationReplace">
+    <xpath>/Defs/ThingDef[defName="FuelStorage"]/costList</xpath>
+    <value>
+      <costList>
+        <Steel>100</Steel>
+        <ComponentIndustrial>1</ComponentIndustrial>
+        <VFEC_BlocksConcrete>35</VFEC_BlocksConcrete>
+      </costList>
+    </value>
+  </Operation>
+</Patch>

--- a/1.6/SpaceSolarPanelGlass/Patches/SpaceSolarPanelGlass_patch.xml
+++ b/1.6/SpaceSolarPanelGlass/Patches/SpaceSolarPanelGlass_patch.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+	<Operation Class="PatchOperationAdd">
+	  <xpath>/Defs/ThingDef[defName="AV_SolarPanel_small"]/costList</xpath>
+	  <value>
+		<Glass>4</Glass>
+	  </value>
+	</Operation>
+	
+	<Operation Class="PatchOperationAdd">
+	  <xpath>/Defs/ThingDef[defName="AV_SolarPanel_wide"]/costList</xpath>
+	  <value>
+		<Glass>6</Glass>
+	  </value>
+	</Operation>
+</Patch>

--- a/1.6/VFEArchitectConcrete/Patches/VFEArchitectConcrete_patch.xml
+++ b/1.6/VFEArchitectConcrete/Patches/VFEArchitectConcrete_patch.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+<Operation Class="PatchOperationReplace">
+        <xpath>/Defs/TerrainDef[defName="VFEArch_ConcreteFoundation"]/costList</xpath>
+        <value>
+            <costList>
+                <VFEC_BlocksConcrete>5</VFEC_BlocksConcrete>
+            </costList>
+        </value>
+    </Operation>
+</Patch>

--- a/1.6/VFEClassical/Patches/VFE_Classic_patch.xml
+++ b/1.6/VFEClassical/Patches/VFE_Classic_patch.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+    <Operation Class="PatchOperationAdd">
+        <xpath>/Defs/PipeSystem.ProcessDef[defName="VFEC_PressConcrete"]/ingredients</xpath>
+        <value>
+            <li>
+                <thing>SR_Sand</thing>
+                <countNeeded>8</countNeeded>
+            </li>
+        </value>
+    </Operation>
+	
+	 <!-- Replace concrete terrain cost with VFEC concrete blocks -->
+    <Operation Class="PatchOperationReplace">
+        <xpath>/Defs/TerrainDef[defName="Concrete"]/costList</xpath>
+        <value>
+            <costList>
+                <VFEC_BlocksConcrete>1</VFEC_BlocksConcrete>
+            </costList>
+        </value>
+    </Operation>
+
+    <!-- Replace paved terrain costs with VFEC concrete blocks (using contains for fuzzy matching) -->
+    <Operation Class="PatchOperationReplace">
+        <xpath>/Defs/TerrainDef[contains(defName, "Paved") or contains(defName, "Asphalt") or contains(label, "paved") or contains(label, "asphalt")]/costList</xpath>
+        <value>
+            <costList>
+                <VFEC_BlocksConcrete>2</VFEC_BlocksConcrete>
+            </costList>
+        </value>
+    </Operation>
+	
+	<!-- Add concrete to Geothermal Generator -->
+	<Operation Class="PatchOperationAdd">
+	  <xpath>/Defs/ThingDef[defName="GeothermalGenerator"]/costList</xpath>
+	  <value>
+		<VFEC_BlocksConcrete>85</VFEC_BlocksConcrete>
+	  </value>
+	</Operation>
+</Patch>

--- a/1.6/VFEFarming/Patches/VFEFarming_patch.xml
+++ b/1.6/VFEFarming/Patches/VFEFarming_patch.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+  <!-- Add soil requirement to regular planter box (4x2 = 8 tiles) -->
+  <Operation Class="PatchOperationAdd">
+    <xpath>/Defs/ThingDef[defName="VFE_PlanterBox"]</xpath>
+    <value>
+      <costList>
+        <SR_Soil>56</SR_Soil>
+      </costList>
+    </value>
+  </Operation>
+
+  <!-- Add soil requirement to tilable planter box (1x1 tile) -->
+  <Operation Class="PatchOperationAdd">
+    <xpath>/Defs/ThingDef[defName="VFE_PlanterBox_Tilable"]</xpath>
+    <value>
+      <costList>
+        <SR_Soil>7</SR_Soil>
+      </costList>
+    </value>
+  </Operation>
+</Patch>

--- a/1.6/VFEHardleatherConcrete/Patches/VFEHardleatherConcrete_patch.xml
+++ b/1.6/VFEHardleatherConcrete/Patches/VFEHardleatherConcrete_patch.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+<!-- Fast concrete press from chunks -->
+    <Operation Class="PatchOperationAdd">
+        <xpath>/Defs/PipeSystem.ProcessDef[defName="talias_PressConcreteFast"]/ingredients</xpath>
+        <value>
+            <li>
+                <thing>SR_Sand</thing>
+                <countNeeded>8</countNeeded>
+            </li>
+        </value>
+    </Operation>
+
+    <!-- Press concrete from 100 blocks (talias version) -->
+    <Operation Class="PatchOperationAdd">
+        <xpath>/Defs/PipeSystem.ProcessDef[defName="talias_PressConcreteFromBlocks"]/ingredients</xpath>
+        <value>
+            <li>
+                <thing>SR_Sand</thing>
+                <countNeeded>10</countNeeded>
+            </li>
+        </value>
+    </Operation>
+
+    <!-- Press concrete from 50 blocks (talias version) -->
+    <Operation Class="PatchOperationAdd">
+        <xpath>/Defs/PipeSystem.ProcessDef[defName="talias_PressConcreteFromBlocksHalf"]/ingredients</xpath>
+        <value>
+            <li>
+                <thing>SR_Sand</thing>
+                <countNeeded>5</countNeeded>
+            </li>
+        </value>
+    </Operation>
+
+    <!-- Press concrete from 100 blocks (VFEC version) -->
+    <Operation Class="PatchOperationAdd">
+        <xpath>/Defs/PipeSystem.ProcessDef[defName="VFEC_PressConcreteFromBlocks"]/ingredients</xpath>
+        <value>
+            <li>
+                <thing>SR_Sand</thing>
+                <countNeeded>10</countNeeded>
+            </li>
+        </value>
+    </Operation>
+
+    <!-- Press concrete from 50 blocks (VFEC version) -->
+    <Operation Class="PatchOperationAdd">
+        <xpath>/Defs/PipeSystem.ProcessDef[defName="VFEC_PressConcreteFromBlocksHalf"]/ingredients</xpath>
+        <value>
+            <li>
+                <thing>SR_Sand</thing>
+                <countNeeded>5</countNeeded>
+            </li>
+        </value>
+    </Operation>
+</Patch>

--- a/1.6/VFEPowerConcrete/Patches/VFEPower_patch.xml
+++ b/1.6/VFEPowerConcrete/Patches/VFEPower_patch.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+    <!-- Add concrete to Tidal Generator -->
+	<Operation Class="PatchOperationAdd">
+	  <xpath>/Defs/ThingDef[defName="VFE_TidalGenerator"]/costList</xpath>
+	  <value>
+		<VFEC_BlocksConcrete>70</VFEC_BlocksConcrete>
+	  </value>
+	</Operation>
+</Patch>

--- a/1.6/VFEPowerGlass/Patches/VFEPowerGlass_patch.xml
+++ b/1.6/VFEPowerGlass/Patches/VFEPowerGlass_patch.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+	<Operation Class="PatchOperationAdd">
+	  <xpath>/Defs/ThingDef[defName="VFE_AdvancedSolarGenerator"]/costList</xpath>
+	  <value>
+		<ReinforcedGlass>50</ReinforcedGlass>
+	  </value>
+	</Operation>
+</Patch>

--- a/About/About.xml
+++ b/About/About.xml
@@ -27,6 +27,18 @@
   <loadAfter>
     <li>brrainz.harmony</li>
     <li>Mlie.ConsistentMapStone</li>
+	<li>OskarPotocki.VFE.Classical</li>
+	<li>talias.VFEHardleatherConcrete</li>
+	<li>VanillaExpanded.VFEArchitect</li>
+	<li>VanillaExpanded.VFEPower</li>
+	<li>VanillaExpanded.VFEFarming</li>
+	<li>Dubwise.Rimatomics</li>
+	<li>Dubwise.Rimefeller</li>
+	<li>ReBuild.COTR.DoorsAndCorners</li>
+	<li>NanoCE.GlassLights</li>
+	<li>Dubwise.DubsSkylights</li>
+	<li>Owlchemist.WallUtilities</li>
+	<li>Veltaris.SpaceSolar</li>
   </loadAfter>
   <description>[img]https://i.imgur.com/buuPQel.png[/img]
 Update of Evelyns mod https://steamcommunity.com/sharedfiles/filedetails/?id=2654088143

--- a/LoadFolders.xml
+++ b/LoadFolders.xml
@@ -19,5 +19,17 @@
     <li>/</li>
     <li>1.6</li>
     <li>Assets</li>
+    <li IfModActive="OskarPotocki.VFE.Classical">1.6/VFEClassical</li>
+	<li IfModActive="VanillaExpanded.VFEFarming">1.6/VFEFarming</li>
+    <li IfModActive="talias.VFEHardleatherConcrete">1.6/VFEHardleatherConcrete</li>
+	<li IfModActive="NanoCE.GlassLights">1.6/NanoGlassPatch</li>
+	<li IfModActiveAll="NanoCE.GlassLights,Owlchemist.WallUtilities">1.6/OwlWallUtils</li>
+	<li IfModActiveAll="VanillaExpanded.VFEArchitect,OskarPotocki.VFE.Classical">1.6/VFEArchitectConcrete</li>
+	<li IfModActiveAll="VanillaExpanded.VFEPower,OskarPotocki.VFE.Classical">1.6/VFEPowerConcrete</li>
+	<li IfModActiveAll="Dubwise.Rimatomics,OskarPotocki.VFE.Classical">1.6/RimatomicsConcrete</li>
+	<li IfModActiveAll="Dubwise.Rimefeller,OskarPotocki.VFE.Classical">1.6/RimefellerConcrete</li>
+	<li IfModActiveAll="ReBuild.COTR.DoorsAndCorners,NanoCE.GlassLights">1.6/RebuildPatchNanoGlass</li>
+	<li IfModActiveAll="VanillaExpanded.VFEPower,NanoCE.GlassLights">1.6/VFEPowerGlass</li>
+	<li IfModActiveAll="Veltaris.SpaceSolar,NanoCE.GlassLights">1.6/SpaceSolarPanelGlass</li>
   </v1.6>
 </loadFolders>


### PR DESCRIPTION
Patches for:
*Vanilla so pots use soil
*VFE Classical so concrete uses sand from this mod, and anything that should use concrete will use concrete
*VFE Farming so planter boxes use soil from this mod
*Talias Industrial Hardleather and Concrete so the new buildings also use sand from this mod
*Nano's Glass+Lights so it uses sand from this mod, and adds glass to shuttles, lamps, TVs/Computers, Mirrors
*Owlchemist Wall Utilities so it removes redundant stuff from Nano's Glass+Lights if both used together
*VFE Architect/Classical if both present to use concrete in concrete foundations
*VFE Power/Classical if both present to use concrete in Tidal Generator base
*VFE Classical/Rimatomics if both present to use concrete in all relevant buildings
*VFE Classical/Rimefeller if both present to use concrete in all relevant buildings
*VFE Power/Glass+lights if both present to use reinforced glass in advanced solar generators
*Rebuild Doors and Corners/Glass+Lights to use Nano's glass and remove redundant door and window from Nano's Glass+Lights *[AV] Space Solar Panels and Corners/Glass+Lights to use Nano's glass in solar generators

**Summary: Adds sand, soil, concrete and glass to whatever makes sense**